### PR TITLE
(#37) Invalid links should show the inner_text not the link url 

### DIFF
--- a/lib/html_parser.c
+++ b/lib/html_parser.c
@@ -2336,8 +2336,8 @@ static void parse_middle_link(html_parser* parser, html_buffer* buffer, size_t s
     // Turn invalid links to text items
     if (item.item.link.url.size != HTML_LINK_SIZE) {
         item.type = HTML_TEXT;
-        item.item.text.size = item.item.link.url.size;
-        strcpy(item.item.text.text, item.item.link.url.text);
+        item.item.text.size = item.item.link.inner_text.size;
+        strcpy(item.item.text.text, item.item.link.inner_text.text);
     }
 
     // append item to row

--- a/tests/check_parser.c
+++ b/tests/check_parser.c
@@ -137,7 +137,7 @@ START_TEST(parse_html_test_page_100)
     m_empty(3);
     m_size(4, 5);
     m_text(4, 0, 5, "     ");
-    m_text(4, 1, 23, "https://yle.fi/tekstitv");
+    m_text(4, 1, 15, "yle.fi/tekstitv");
     m_text(4, 2, 4, "    ");
     m_link(4, 3, "199_0001.htm", 3, "199");
     m_text(4, 4, 15, " PÄÄHAKEMISTO");


### PR DESCRIPTION
Close #37 