### PR TITLE
(#46) Clang now loads default conf correctly

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -390,9 +390,9 @@ static void load_config(char* filepath)
 {
     // Don't report missing file when trying to load the file from default path.
     bool default_config = false;
+    char tmp_dir[1024];
     if (filepath == NULL) {
         // Let's hope the file path is under 1024 characters
-        char tmp_dir[1024];
         char* homedir;
         // Try to find the home path from $HOME variable
         // If and if not found, use the uid


### PR DESCRIPTION
In src/config.c the load_conf function didn't load
the default config file when -O3 flag was used
to optimize the binary. Moving the tmp_dir variable
to a different scope seems to fix the issue.

This might be a bug with the clang compiler.
Consider reporting this.

Close #46 