### PR TITLE
Try to match the drawer locale with env language

### DIFF
--- a/src/drawer.c
+++ b/src/drawer.c
@@ -1,4 +1,8 @@
+#ifndef DISABLE_UTF8
 #include <locale.h>
+#include <stdlib.h>
+#endif
+
 #include <string.h>
 #include <tekstitv.h>
 
@@ -896,8 +900,17 @@ void init_drawer(drawer* drawer)
 {
 #ifndef DISABLE_UTF_8
     // Make sure that locale is set so ncurses can show UTF-8 properly
-    // Just default to en_US. This program doesn't really use locale anywhere else
-    setlocale(LC_ALL, "en_US.UTF-8");
+    // Set the locale as the enviroment language
+    // Language is usually in either LANG or LANGUAGE env variable
+    char* lang = getenv("LANG");
+    if (lang == NULL)
+        lang = getenv("LANGUAGE");
+
+    // Lang is either the env variable or an empty string
+    if (lang == NULL)
+        lang = "";
+
+    setlocale(LC_ALL, lang);
 #endif
     // Start curses mode
     initscr();


### PR DESCRIPTION
This should make the ncruses utf8 suppor more consistent
across all devices