### PR TITLE
Reinit navigation links when resizing a window

### DIFF
--- a/src/drawer.c
+++ b/src/drawer.c
@@ -267,7 +267,7 @@ static int handle_getch(drawer* drawer, html_parser* parser)
     int c = getch();
     if (c == KEY_RESIZE) {
         set_main_window_size(drawer);
-        redraw_parser(drawer, parser, false, false);
+        redraw_parser(drawer, parser, true, false);
     }
 
     return c;


### PR DESCRIPTION
If navgiation links aren't reinitialized, the nagation
will stop working after a resize

Close #54 